### PR TITLE
OPS-4449: Add ability to convert nils to a floating point zero (0.0)

### DIFF
--- a/lib/check_graphite.rb
+++ b/lib/check_graphite.rb
@@ -23,7 +23,7 @@ module CheckGraphite
     enable_timeout
 
     def check
-      raise 'Invalid value for --niltozero (true or false)' unless options.niltozero == 'true' or options.niltozero == 'false'
+      raise 'Invalid value for --niltozero (true or false)' unless options.niltozero == 'true' || options.niltozero == 'false'
 
       uri = URI(URI.encode("#{options.endpoint}?target=#{options.metric}&from=-#{options.from}&format=json"))
       req = Net::HTTP::Get.new(uri.request_uri)
@@ -50,7 +50,7 @@ module CheckGraphite
       datapoints.reject! { |v| v.first.nil? } unless options.niltozero == 'true'
       raise "no valid datapoints" if datapoints.size == 0
 
-      sum = datapoints.reduce(0.0) {|acc, v| acc + v.first.to_f }
+      sum = datapoints.reduce(0.0) { |acc, v| acc + v.first.to_f }
       value = sum / datapoints.size
       store_value options.name, value
       store_message "#{options.name}=#{value}"

--- a/lib/check_graphite/version.rb
+++ b/lib/check_graphite/version.rb
@@ -1,3 +1,3 @@
 module CheckGraphite
-  VERSION = "0.3.0"
+  VERSION = "0.2.3"
 end

--- a/lib/check_graphite/version.rb
+++ b/lib/check_graphite/version.rb
@@ -1,3 +1,3 @@
 module CheckGraphite
-  VERSION = "0.2.3"
+  VERSION = "0.3.0"
 end


### PR DESCRIPTION
Rather than failing when all data points are nil, convert them to zeros. This allows for metrics that only have data when a condition is met.
